### PR TITLE
Add "Verify Email" message flashing

### DIFF
--- a/flask_stormpath/views.py
+++ b/flask_stormpath/views.py
@@ -83,6 +83,11 @@ def register():
                 # STORMPATH_REDIRECT_URL setting.
                 login_user(account, remember=True)
 
+                # The email address must be verified, so pop an alert about it.
+                if current_app.config['STORMPATH_VERIFY_EMAIL'] is True:
+                    flash('You must validate your email address before logging '
+                          'in. Please check your email for instructions.')
+
                 if 'STORMPATH_REGISTRATION_REDIRECT_URL'\
                         in current_app.config:
                     redirect_url = current_app.config[


### PR DESCRIPTION
This was causing a lot of confusion with users signing up for new accounts, wanting to log in before they receive the verification emails.  I saw that `STORMPATH_VERIFY_EMAIL` was in `settings.py` already (but not being used in code), so I used that and flash a message based when set to True.
