### PR TITLE
Blinker and Python3

### DIFF
--- a/flask_stormpath/models.py
+++ b/flask_stormpath/models.py
@@ -58,15 +58,16 @@ class User(Account):
         Send signal after user is updated.
         """
         return_value = super(User, self).save()
-        user_updated.send(self, user=self)
+        user_updated.send(self, user=dict(self))
         return return_value
 
     def delete(self):
         """
         Send signal after user is deleted.
         """
+        user_dict = dict(self)
         return_value = super(User, self).delete()
-        user_deleted.send(self, user=self)
+        user_deleted.send(None, user=user_dict)
         return return_value
 
     @classmethod
@@ -109,7 +110,7 @@ class User(Account):
             'status': status,
         })
         _user.__class__ = User
-        user_created.send(self, user=_user)
+        user_created.send(self, user=dict(_user))
 
         return _user
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx>=1.2.1
 pytest>=2.5.2
 pytest-xdist>=1.10
-blinker==1.3
+blinker==1.4

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 """Tests for our data models."""
 
 
-from flask.ext.stormpath.models import User
+from flask_stormpath.models import User
 from stormpath.resources.account import Account
 
 from .helpers import StormpathTestCase

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,7 +1,7 @@
 """Run tests for signals."""
 
 from flask.ext.login import user_logged_in
-from flask.ext.stormpath.models import (
+from flask_stormpath.models import (
     User,
     user_created,
     user_deleted,
@@ -34,11 +34,11 @@ class TestSignals(StormpathTestCase):
         self.assertEqual(len(signal_receiver.received_signals), 1)
         received_signal = signal_receiver.received_signals[0]
         # User instance is received
-        self.assertIsInstance(received_signal[1], User)
+        self.assertIsInstance(received_signal[1], dict)
         # Correct user instance is received
         created_user = received_signal[1]
-        self.assertEqual(created_user.email, 'r@rdegges.com')
-        self.assertEqual(created_user.surname, 'Degges')
+        self.assertEqual(created_user['email'], 'r@rdegges.com')
+        self.assertEqual(created_user['surname'], 'Degges')
 
     def test_user_logged_in_signal(self):
         # Subscribe to signals for user login
@@ -95,11 +95,11 @@ class TestSignals(StormpathTestCase):
         self.assertEqual(len(signal_receiver.received_signals), 1)
         received_signal = signal_receiver.received_signals[0]
         # User instance is received
-        self.assertIsInstance(received_signal[1], User)
+        self.assertIsInstance(received_signal[1], dict)
         # Correct user instance is received
         updated_user = received_signal[1]
-        self.assertEqual(updated_user.email, 'r@rdegges.com')
-        self.assertEqual(updated_user.middle_name, 'Clark')
+        self.assertEqual(updated_user['email'], 'r@rdegges.com')
+        self.assertEqual(updated_user['middle_name'], 'Clark')
 
     def test_user_is_deleted_signal(self):
         # Subscribe to signals for user delete
@@ -122,7 +122,7 @@ class TestSignals(StormpathTestCase):
         self.assertEqual(len(signal_receiver.received_signals), 1)
         received_signal = signal_receiver.received_signals[0]
         # User instance is received
-        self.assertIsInstance(received_signal[1], User)
+        self.assertIsInstance(received_signal[1], dict)
         # Correct user instance is received
         deleted_user = received_signal[1]
-        self.assertEqual(deleted_user.email, 'r@rdegges.com')
+        self.assertEqual(deleted_user['email'], 'r@rdegges.com')


### PR DESCRIPTION
We were using blinker version that was not compatible with Python 3.4.
This PR fixes that. This should complete #26 .