### PR TITLE
Fix the base screen style.

### DIFF
--- a/flask_stormpath/templates/flask_stormpath/base.html
+++ b/flask_stormpath/templates/flask_stormpath/base.html
@@ -23,7 +23,12 @@
           padding: 0 4px;
         }
       }
-
+      
+      body {
+        margin-left: auto;
+        margin-right: auto;
+      }
+      
       body,
       div,
       p,


### PR DESCRIPTION
This modification will center the login view container. 

See http://igorrcosta.pythonanywhere.com/login on any screen size for an example of the bug.
This change was already made on the express-stormpath library:
https://github.com/stormpath/express-stormpath/commit/77226f7bdf1fb728d2b1c703fabe042436e4747c