### PR TITLE
replace deprecated import flask.ext.* with new flask_*

### DIFF
--- a/flask_stormpath/__init__.py
+++ b/flask_stormpath/__init__.py
@@ -29,7 +29,7 @@ from flask import (
     current_app,
 )
 
-from flask.ext.login import (
+from flask_login import (
     LoginManager,
     current_user,
     _get_user,

--- a/flask_stormpath/context_processors.py
+++ b/flask_stormpath/context_processors.py
@@ -2,7 +2,7 @@
 
 
 from flask import current_app
-from flask.ext.login import _get_user
+from flask_login import _get_user
 
 
 def user_context_processor():

--- a/flask_stormpath/decorators.py
+++ b/flask_stormpath/decorators.py
@@ -7,7 +7,7 @@ simpler.
 from functools import wraps
 
 from flask import current_app
-from flask.ext.login import current_user
+from flask_login import current_user
 
 
 def groups_required(groups, all=True):

--- a/flask_stormpath/forms.py
+++ b/flask_stormpath/forms.py
@@ -1,7 +1,7 @@
 """Helper forms which make handling common operations simpler."""
 
 
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms.fields import PasswordField, StringField
 from wtforms.validators import InputRequired, ValidationError
 

--- a/flask_stormpath/models.py
+++ b/flask_stormpath/models.py
@@ -96,7 +96,7 @@ class User(Account):
             either 'ENABLED', 'DISABLED', or 'UNVERIFIED'.
 
         If something goes wrong we'll raise an exception -- most likely -- a
-        `StormpathError` (flask.ext.stormpath.StormpathError).
+        `StormpathError` (flask_stormpath.StormpathError).
         """
         _user = current_app.stormpath_manager.application.accounts.create({
             'email': email,
@@ -120,7 +120,7 @@ class User(Account):
         password.
 
         If something goes wrong, this will raise an exception -- most likely --
-        a `StormpathError` (flask.ext.stormpath.StormpathError).
+        a `StormpathError` (flask_stormpath.StormpathError).
         """
         _user = current_app.stormpath_manager.application.authenticate_account(login, password).account
         _user.__class__ = User
@@ -136,7 +136,7 @@ class User(Account):
         Login).
 
         If something goes wrong, this will raise an exception -- most likely --
-        a `StormpathError` (flask.ext.stormpath.StormpathError).
+        a `StormpathError` (flask_stormpath.StormpathError).
         """
         _user = current_app.stormpath_manager.application.get_provider_account(
             code = code,
@@ -155,7 +155,7 @@ class User(Account):
         Login).
 
         If something goes wrong, this will raise an exception -- most likely --
-        a `StormpathError` (flask.ext.stormpath.StormpathError).
+        a `StormpathError` (flask_stormpath.StormpathError).
         """
         _user = current_app.stormpath_manager.application.get_provider_account(
             access_token = access_token,

--- a/flask_stormpath/views.py
+++ b/flask_stormpath/views.py
@@ -10,7 +10,7 @@ from flask import (
     render_template,
     request,
 )
-from flask.ext.login import login_user
+from flask_login import login_user
 from six import string_types
 from stormpath.resources.provider import Provider
 


### PR DESCRIPTION
in Flask 0.11 is call `flask.ext.*` marked as deprecated and should be replaced with `flask_*`

changelog: http://flask.pocoo.org/docs/0.11/changelog/