### PR TITLE
Change flash() in StormpathError to take in unicode string rather than dict

### DIFF
--- a/flask_stormpath/views.py
+++ b/flask_stormpath/views.py
@@ -92,7 +92,7 @@ def register():
                 return redirect(redirect_url)
 
             except StormpathError as err:
-                flash(err.message.get('message'))
+                flash(err.message)
 
     return render_template(
         current_app.config['STORMPATH_REGISTRATION_TEMPLATE'],
@@ -130,7 +130,7 @@ def login():
             return redirect(request.args.get('next') or current_app.config['STORMPATH_REDIRECT_URL'])
 
         except StormpathError as err:
-            flash(err.message.get('message'))
+            flash(err.message)
 
     return render_template(
         current_app.config['STORMPATH_LOGIN_TEMPLATE'],
@@ -219,7 +219,7 @@ def forgot_change():
             if isinstance(err.message, string_types) and 'https' in err.message.lower():
                 flash('Something went wrong! Please try again.')
             else:
-                flash(err.message.get('message'))
+                flash(err.message)
 
     # If this is a POST request, and the form isn't valid, this means the
     # user's password was no good, so we'll display a message.


### PR DESCRIPTION
From stormpath version 2.2.0 and later, the `flash` function should be simply passing `err.message` in, rather than think it's a dictionary object.

This is the stack trace without the fix,

```
Traceback (most recent call last):
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 2000, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1991, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1567, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/conda_env/lib/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/conda_env/lib/python2.7/site-packages/flask_stormpath/views.py", line 98, in register
    flash(err.message.get('message'))
AttributeError: 'unicode' object has no attribute 'get'
```

## Versions
```
Flask-Stormpath==0.4.5
stormpath==2.4.0
Flask=0.10.1
```