### PR TITLE
Convert `is_authenticated`, `is_active`, and `is_anonymous` to properties to conform with Flask-Login >=0.3.0

### DIFF
--- a/flask_stormpath/decorators.py
+++ b/flask_stormpath/decorators.py
@@ -44,7 +44,7 @@ def groups_required(groups, all=True):
                 return func(*args, **kwargs)
 
             # If the user is NOT authenticated, this user is unauthorized.
-            elif not current_user.is_authenticated():
+            elif not current_user.is_authenticated:
                 return current_app.login_manager.unauthorized()
 
             # If the user authenticated, and the all flag is set, we need to

--- a/flask_stormpath/models.py
+++ b/flask_stormpath/models.py
@@ -33,6 +33,7 @@ class User(Account):
         """
         return text_type(self.href)
 
+    @property
     def is_active(self):
         """
         A user account is active if, and only if, their account status is
@@ -40,12 +41,14 @@ class User(Account):
         """
         return self.status == 'ENABLED'
 
+    @property
     def is_anonymous(self):
         """
         We don't support anonymous users, so this is always False.
         """
         return False
 
+    @property
     def is_authenticated(self):
         """
         All users will always be authenticated, so this will always return

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -75,17 +75,17 @@ class TestUser(StormpathTestCase):
                 given_name = 'Randall',
                 surname = 'Degges',
             )
-            self.assertEqual(user.is_active(), True)
+            self.assertEqual(user.is_active, True)
 
             # Ensure users who have their accounts explicitly disabled actually
             # return a proper status when `is_active` is called.
             user.status = User.STATUS_DISABLED
-            self.assertEqual(user.is_active(), False)
+            self.assertEqual(user.is_active, False)
 
             # Ensure users who have not verified their accounts return a proper
             # status when `is_active` is called.
             user.status = User.STATUS_UNVERIFIED
-            self.assertEqual(user.is_active(), False)
+            self.assertEqual(user.is_active, False)
 
     def test_is_anonymous(self):
         with self.app.app_context():
@@ -99,7 +99,7 @@ class TestUser(StormpathTestCase):
                 given_name = 'Randall',
                 surname = 'Degges',
             )
-            self.assertEqual(user.is_anonymous(), False)
+            self.assertEqual(user.is_anonymous, False)
 
     def test_is_authenticated(self):
         with self.app.app_context():
@@ -112,7 +112,7 @@ class TestUser(StormpathTestCase):
                 given_name = 'Randall',
                 surname = 'Degges',
             )
-            self.assertEqual(user.is_authenticated(), True)
+            self.assertEqual(user.is_authenticated, True)
 
     def test_create(self):
         with self.app.app_context():


### PR DESCRIPTION
`@groups_required` decorator no longer works after upgrading `stormpath-flask` to the latest release because of this.. 