### PR TITLE
Use standard WTForm validation for 'register' page.

### DIFF
--- a/flask_stormpath/forms.py
+++ b/flask_stormpath/forms.py
@@ -28,8 +28,8 @@ class RegistrationForm(Form):
     given_name = StringField('First Name')
     middle_name = StringField('Middle Name')
     surname = StringField('Last Name')
-    email = StringField('Email', validators=[InputRequired()])
-    password = PasswordField('Password', validators=[InputRequired()])
+    email = StringField('Email', validators=[InputRequired('You must provide a valid email address.')])
+    password = PasswordField('Password', validators=[InputRequired('You must supply a password.')])
 
     def __init__(self, formdata=_Auto, obj=None, prefix='', csrf_context=None, secret_key=None, csrf_enabled=None,
                  config=None, *args, **kwargs):

--- a/flask_stormpath/forms.py
+++ b/flask_stormpath/forms.py
@@ -97,5 +97,5 @@ class ChangePasswordForm(Form):
     password = PasswordField('Password', validators=[InputRequired('Password required.')])
     password_again = PasswordField('Password (again)', validators=[
         InputRequired('Please verify the password.'),
-        EqualTo(password, 'Passwords don\'t match.')
+        EqualTo('password', 'Passwords do not match.')
     ])

--- a/flask_stormpath/forms.py
+++ b/flask_stormpath/forms.py
@@ -4,7 +4,7 @@
 from flask_wtf import Form
 from flask_wtf.form import _Auto
 from wtforms.fields import PasswordField, StringField
-from wtforms.validators import InputRequired, ValidationError
+from wtforms.validators import Email, EqualTo, InputRequired, ValidationError
 
 
 class RegistrationForm(Form):
@@ -28,7 +28,10 @@ class RegistrationForm(Form):
     given_name = StringField('First Name')
     middle_name = StringField('Middle Name')
     surname = StringField('Last Name')
-    email = StringField('Email', validators=[InputRequired('You must provide a valid email address.')])
+    email = StringField('Email', validators=[
+        InputRequired('You must provide an email address.'),
+        Email('You must provide a valid email address.')
+    ])
     password = PasswordField('Password', validators=[InputRequired('You must supply a password.')])
 
     def __init__(self, formdata=_Auto, obj=None, prefix='', csrf_context=None, secret_key=None, csrf_enabled=None,
@@ -67,8 +70,8 @@ class LoginForm(Form):
         Since social login stuff is handled separately (login happens through
         Javascript) we don't need to have a form for logging in users that way.
     """
-    login = StringField('Login', validators=[InputRequired()])
-    password = PasswordField('Password', validators=[InputRequired()])
+    login = StringField('Login', validators=[InputRequired('Login identifier required.')])
+    password = PasswordField('Password', validators=[InputRequired('Password required.')])
 
 
 class ForgotPasswordForm(Form):
@@ -78,7 +81,10 @@ class ForgotPasswordForm(Form):
 
     This class is used to retrieve a user's email address.
     """
-    email = StringField('Email', validators=[InputRequired()])
+    email = StringField('Email', validators=[
+        InputRequired('Email address required.'),
+        Email('You must provide a valid email address.')
+    ])
 
 
 class ChangePasswordForm(Form):
@@ -88,14 +94,8 @@ class ChangePasswordForm(Form):
     This class is used to retrieve a user's password twice to ensure it's valid
     before making a change.
     """
-    password = PasswordField('Password', validators=[InputRequired()])
-    password_again = PasswordField('Password (again)', validators=[InputRequired()])
-
-    def validate_password_again(self, field):
-        """
-        Ensure both password fields match, otherwise raise a ValidationError.
-
-        :raises: ValidationError if passwords don't match.
-        """
-        if self.password.data != field.data:
-            raise ValidationError("Passwords don't match.")
+    password = PasswordField('Password', validators=[InputRequired('Password required.')])
+    password_again = PasswordField('Password (again)', validators=[
+        InputRequired('Please verify the password.'),
+        EqualTo(password, 'Passwords don\'t match.')
+    ])

--- a/flask_stormpath/forms.py
+++ b/flask_stormpath/forms.py
@@ -2,6 +2,7 @@
 
 
 from flask_wtf import Form
+from flask_wtf.form import _Auto
 from wtforms.fields import PasswordField, StringField
 from wtforms.validators import InputRequired, ValidationError
 
@@ -29,6 +30,24 @@ class RegistrationForm(Form):
     surname = StringField('Last Name')
     email = StringField('Email', validators=[InputRequired()])
     password = PasswordField('Password', validators=[InputRequired()])
+
+    def __init__(self, formdata=_Auto, obj=None, prefix='', csrf_context=None, secret_key=None, csrf_enabled=None,
+                 config=None, *args, **kwargs):
+        super(RegistrationForm, self).__init__(formdata, obj, prefix, csrf_context, secret_key, csrf_enabled, *args,
+                                               **kwargs)
+
+        if config:
+            if config['STORMPATH_ENABLE_USERNAME'] and config['STORMPATH_REQUIRE_USERNAME']:
+                self.username.validators.append(InputRequired('Username is required.'))
+
+            if config['STORMPATH_ENABLE_GIVEN_NAME'] and config['STORMPATH_REQUIRE_GIVEN_NAME']:
+                self.given_name.validators.append(InputRequired('First name is required.'))
+
+            if config['STORMPATH_ENABLE_MIDDLE_NAME'] and config['STORMPATH_REQUIRE_MIDDLE_NAME']:
+                self.middle_name.validators.append(InputRequired('Middle name is required.'))
+
+            if config['STORMPATH_ENABLE_SURNAME'] and config['STORMPATH_REQUIRE_SURNAME']:
+                self.surname.validators.append(InputRequired('Surname is required.'))
 
 
 class LoginForm(Form):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class RunTests(Command):
 
     def run(self):
         """Run our tests!"""
-        errno = call(['py.test', '-n', str(cpu_count())])
+        errno = call(['py.test', '-n', str(cpu_count()), 'tests/'])
         raise SystemExit(errno)
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -23,6 +23,7 @@ class TestRegister(StormpathTestCase):
 
             # Ensure that valid fields will result in a success.
             resp = c.post('/register', data={
+                'username': 'rdegges',
                 'given_name': 'Randall',
                 'middle_name': 'Clark',
                 'surname': 'Degges',
@@ -34,6 +35,7 @@ class TestRegister(StormpathTestCase):
     def test_disable_all_except_mandatory(self):
         # Here we'll disable all the fields except for the mandatory fields:
         # email and password.
+        self.app.config['STORMPATH_ENABLE_USERNAME'] = False
         self.app.config['STORMPATH_ENABLE_GIVEN_NAME'] = False
         self.app.config['STORMPATH_ENABLE_MIDDLE_NAME'] = False
         self.app.config['STORMPATH_ENABLE_SURNAME'] = False


### PR DESCRIPTION
This PR simplifies the ``/register`` view so that it makes use of the standard WTForm validation rules.

**Why this is necessary:**

The way the code is written now, the ``InputRequired`` validator is never added to the WTForm field, and validation is done in a non-standard way in ``views.register``. This makes it difficult for users to add their own form validation processing (e.g. using a macro as suggested in the [Flask documentation](http://flask.pocoo.org/docs/0.11/patterns/wtforms/#forms-in-templates)), because ``field.errors`` will never be set.

Changes include:
- WTF field requirements are now read directly from  ``STORMPATH_ENABLE_%s`` and  ``STORMPATH_REQUIRE_%s`` 
- ensure that ``python setup.py test`` will only be run for the application's test folder (runs all tests on the Python path otherwise (!?))
- fix test that was ignoring 'username' field requirements