### PR TITLE
Add flask-login >= 0.4.0 compatibility

### DIFF
--- a/flask_stormpath/__init__.py
+++ b/flask_stormpath/__init__.py
@@ -32,11 +32,14 @@ from flask import (
 from flask_login import (
     LoginManager,
     current_user,
-    _get_user,
     login_required,
     login_user,
     logout_user,
 )
+try:
+    from flask_login.utils import _get_user
+except ImportError:
+    from flask_login import _get_user
 
 from stormpath.client import Client
 from stormpath.error import Error as StormpathError

--- a/flask_stormpath/context_processors.py
+++ b/flask_stormpath/context_processors.py
@@ -2,7 +2,10 @@
 
 
 from flask import current_app
-from flask_login import _get_user
+try:
+    from flask_login.utils import _get_user
+except ImportError:
+    from flask_login import _get_user
 
 
 def user_context_processor():


### PR DESCRIPTION
flask-login 0.4.0 moves `_get_user` to `flask_login.utils`.