### PR TITLE
Cleanup unit tests.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,8 +11,9 @@ from unittest import TestCase
 from uuid import uuid4
 
 from flask import Flask
-from flask.ext.stormpath import StormpathManager
+from flask_stormpath import StormpathManager
 from stormpath.client import Client
+from stormpath.error import Error
 
 
 class StormpathTestCase(TestCase):
@@ -41,6 +42,19 @@ class StormpathTestCase(TestCase):
         # Clean up the directories.
         for directory in self.client.directories.search(app_name):
             directory.delete()
+
+        # Clean up API keys
+        self.delete_api_key(app_name)
+
+    def delete_api_key(self, app_name):
+        try:
+            for account in self.client.accounts.items:
+                for key in account.api_keys.items:
+                    if key.name and app_name in key.name:
+                        self.client.data_store.delete_resource(key.href)
+        except Error:
+            # Resource not found - ignore.
+            pass
 
 
 class SignalReceiver(object):

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,8 +1,9 @@
 """Run tests against our custom context processors."""
 
 
-from flask.ext.stormpath import User, user
-from flask.ext.stormpath.context_processors import user_context_processor
+from flask_stormpath import User, user
+from flask_stormpath.context_processors import user_context_processor
+from stormpath.error import Error
 
 from .helpers import StormpathTestCase
 
@@ -22,6 +23,14 @@ class TestUserContextProcessor(StormpathTestCase):
                 email = 'r@testmail.stormpath.com',
                 password = 'woot1LoveCookies!',
             )
+
+    def tearDown(self):
+        super(TestUserContextProcessor, self).tearDown()
+        try:
+            self.user.delete()
+        except Error:
+            # Resource not found - ignore.
+            pass
 
     def test_raw_works(self):
         with self.app.test_client() as c:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,8 +1,9 @@
 """Run tests against our custom decorators."""
 
 
-from flask.ext.stormpath import User
-from flask.ext.stormpath.decorators import groups_required
+from flask_stormpath import User
+from flask_stormpath.decorators import groups_required
+from stormpath.error import Error
 
 from .helpers import StormpathTestCase
 
@@ -31,6 +32,24 @@ class TestGroupsRequired(StormpathTestCase):
             self.developers = self.application.groups.create({
                 'name': 'developers',
             })
+
+    def tearDown(self):
+        super(TestGroupsRequired, self).tearDown()
+        try:
+            self.user.delete()
+        except Error:
+            # Resource not found - ignore.
+            pass
+        try:
+            self.admins.delete()
+        except Error:
+            # Resource not found - ignore.
+            pass
+        try:
+            self.developers.delete()
+        except Error:
+            # Resource not found - ignore.
+            pass
 
     def test_defaults_to_all(self):
         @self.app.route('/test')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,8 +5,8 @@ from datetime import timedelta
 from os import close, environ, remove, write
 from tempfile import mkstemp
 
-from flask.ext.stormpath.errors import ConfigurationError
-from flask.ext.stormpath.settings import check_settings, init_settings
+from flask_stormpath.errors import ConfigurationError
+from flask_stormpath.settings import check_settings, init_settings
 
 from .helpers import StormpathTestCase
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,6 @@
 """Run tests for signals."""
 
-from flask.ext.login import user_logged_in
+from flask_login import user_logged_in
 from flask_stormpath.models import (
     User,
     user_created,

--- a/tests/test_stormpath.py
+++ b/tests/test_stormpath.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 from uuid import uuid4
 
 from flask import Flask, request
-from flask.ext.stormpath import (
+from flask_stormpath import (
     StormpathManager,
     User,
     groups_required,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 """Run tests against our custom views."""
 
 
-from flask.ext.stormpath.models import User
+from flask_stormpath.models import User
 
 from .helpers import StormpathTestCase
 


### PR DESCRIPTION
Remove Stormpath test resources once the tests have run.

``tearDown()`` will now remove API keys, users, and groups as well and prevent the Stormpath web interface dashboard from being polluted with old test resources.

The only way I could track down the API keys were to iterate through all accounts looking for applications with names in the correct ``flask-stormpath-tests`` format. This seems a little inefficient, but I couldn't find the API keys in the key list of either the application or account resources directly.

I also switched from the deprecated ``flask.ext`` import format to the new ``flask_stormpath`` while I was at it. 

Fixes #83.