### PR TITLE
Filter form fields before passing to User.create()

### DIFF
--- a/flask_stormpath/models.py
+++ b/flask_stormpath/models.py
@@ -74,7 +74,7 @@ class User(Account):
         return return_value
 
     @classmethod
-    def create(self, email, password, given_name, surname, username=None, middle_name=None, custom_data=None, status='ENABLED'):
+    def create(cls, email, password, given_name, surname, username=None, middle_name=None, custom_data=None, status='ENABLED'):
         """
         Create a new User.
 
@@ -113,12 +113,12 @@ class User(Account):
             'status': status,
         })
         _user.__class__ = User
-        user_created.send(self, user=dict(_user))
+        user_created.send(cls, user=dict(_user))
 
         return _user
 
     @classmethod
-    def from_login(self, login, password):
+    def from_login(cls, login, password):
         """
         Create a new User class given a login (`email` or `username`), and
         password.
@@ -132,7 +132,7 @@ class User(Account):
         return _user
 
     @classmethod
-    def from_google(self, code):
+    def from_google(cls, code):
         """
         Create a new User class given a Google access code.
 
@@ -151,7 +151,7 @@ class User(Account):
         return _user
 
     @classmethod
-    def from_facebook(self, access_token):
+    def from_facebook(cls, access_token):
         """
         Create a new User class given a Facebook user's access token.
 

--- a/flask_stormpath/views.py
+++ b/flask_stormpath/views.py
@@ -44,16 +44,20 @@ def register():
         data = form.data
         # Attempt to create the user's account on Stormpath.
         try:
-            # Since Stormpath requires both the given_name and surname
-            # fields be set, we'll just set the both to 'Anonymous' if
-            # the user has # explicitly said they don't want to collect
-            # those fields.
-            data['given_name'] = data['given_name'] or 'Anonymous'
-            data['surname'] = data['surname'] or 'Anonymous'
-
             # Create the user account on Stormpath.  If this fails, an
             # exception will be raised.
-            account = User.create(**data)
+            optional_params = {k: data[k] for k in ('username','middle_name','custom_data', 'status') if k in data}
+            account = User.create(
+                data.get('email'),
+                data.get('password'),
+                # Since Stormpath requires both the given_name and surname
+                # fields be set, we'll just set the both to 'Anonymous' if
+                # the user has # explicitly said they don't want to collect
+                # those fields.
+                data.get('given_name', 'Anonymous') or 'Anonymous',
+                data.get('surname', 'Anonymous') or 'Anonymous',
+                **optional_params
+            )
 
             # If we're able to successfully create the user's account,
             # we'll log the user in (creating a secure session using


### PR DESCRIPTION
Adds support for Flask-WTF>=0.14. In production environments where ``WTF_CSRF_ENABLED`` is enabled, the ``form.data`` will contain a ``csrf_token`` field which is passed to ``User.create()``, causing a TypeError.

Unfortunately I wasn't able to provide a test case for this as creating a test suite that will work with ``WTF_CSRF_ENABLED = True`` is [not a trivial exercise](https://gist.github.com/singingwolfboy/2fca1de64950d5dfed72).

Also fixed the ``@classmethod`` signatures while I was at it.

Fixes #92.